### PR TITLE
(LOG-16729) - Adicionar id nos titulos e informações estáticas do componente

### DIFF
--- a/docs/stories/components/cards/LCard.stories.js
+++ b/docs/stories/components/cards/LCard.stories.js
@@ -14,7 +14,8 @@ export default {
     height: { control: "text", description: "Card height" },
     default: { description: "Card content slot" },
     close: { table: { disable: true } },
-    error: { table: { disable: true } }
+    error: { table: { disable: true } },
+    generateId: { control: 'boolean', description: 'Controls if component will generate id selector for HTML elements' }
   }
 };
 

--- a/src/components/cards/LCard.vue
+++ b/src/components/cards/LCard.vue
@@ -12,6 +12,7 @@
         class="LCard__header"
         :title="title"
         :description="description"
+        :generate-id="generateId"
         @togglecard="$emit('close')"
       />
       <div class="LCard__content">
@@ -52,6 +53,10 @@ export default {
     height: {
       type: String,
       default: null
+    },
+    generateId: {
+      type: Boolean,
+      default: false
     }
   }
 }

--- a/src/components/cards/LCardHeader.vue
+++ b/src/components/cards/LCardHeader.vue
@@ -2,7 +2,7 @@
   <div class="LCardHeader">
     <v-list-item-content class="pa-0 p-0">
       <v-list-item-title class="LCardHeader__title font-md">
-        {{ title }}
+        <span :id="idToSlug(title, 'card')">{{ title }}</span>
       </v-list-item-title>
       <v-list-item-subtitle
         v-if="description"
@@ -15,6 +15,8 @@
 </template>
 
 <script>
+import { slugify } from '~/utils/string.util'
+
 export default {
   props: {
     title: {
@@ -24,6 +26,11 @@ export default {
     description: {
       type: String,
       default: null
+    }
+  },
+  methods: {
+    idToSlug (title, prefix = '') {
+      return prefix + '-' + slugify(title)
     }
   }
 }

--- a/src/components/cards/LCardHeader.vue
+++ b/src/components/cards/LCardHeader.vue
@@ -2,7 +2,7 @@
   <div class="LCardHeader">
     <v-list-item-content class="pa-0 p-0">
       <v-list-item-title class="LCardHeader__title font-md">
-        <span :id="idToSlug(title, 'card')">{{ title }}</span>
+        <span :id="idToSlug(title, 'card-')">{{ title }}</span>
       </v-list-item-title>
       <v-list-item-subtitle
         v-if="description"
@@ -30,7 +30,7 @@ export default {
   },
   methods: {
     idToSlug (title, prefix = '') {
-      return prefix + '-' + slugify(title)
+      return prefix + slugify(title)
     }
   }
 }

--- a/src/components/cards/LCardHeader.vue
+++ b/src/components/cards/LCardHeader.vue
@@ -1,8 +1,11 @@
 <template>
   <div class="LCardHeader">
     <v-list-item-content class="pa-0 p-0">
-      <v-list-item-title class="LCardHeader__title font-md">
-        <span :id="idToSlug(title, 'card-')">{{ title }}</span>
+      <v-list-item-title
+        :id="generateCardId(title, 'cardHeader-')"
+        class="LCardHeader__title font-md"
+      >
+        {{ title }}
       </v-list-item-title>
       <v-list-item-subtitle
         v-if="description"
@@ -26,10 +29,18 @@ export default {
     description: {
       type: String,
       default: null
+    },
+    generateId: {
+      type: Boolean,
+      default: false
     }
   },
   methods: {
-    idToSlug (title, prefix = '') {
+    generateCardId (title, prefix = '') {
+      if (!this.generateId) {
+        return
+      }
+
       return prefix + slugify(title)
     }
   }

--- a/test/components/cards/lCardHeader.spec.ts
+++ b/test/components/cards/lCardHeader.spec.ts
@@ -42,7 +42,7 @@ describe('LCardHeader component', () => {
   })
 })
 
-describe('LCardHeader component rendering items when generateId props true', () => {
+describe('LCardHeader component rendering items when generateId props is true', () => {
   let cardHeader: Wrapper<LCardHeader>
 
   beforeAll(() => {

--- a/test/components/cards/lCardHeader.spec.ts
+++ b/test/components/cards/lCardHeader.spec.ts
@@ -40,4 +40,11 @@ describe('LCardHeader component', () => {
     expect(description().exists()).toBeTruthy()
     expect(description().text()).toBe('Descrição cabeçalho Card')
   })
+
+  it('should return slugged id with prefix when using idToSlug method', async () => {
+    const expansionHeadersWithId = () => cardHeader.findAll('#card-titulo-cabecalho-card')
+    await cardHeader.vm.$nextTick()
+
+    expect(expansionHeadersWithId().length).toBe(1)
+  })
 })

--- a/test/components/cards/lCardHeader.spec.ts
+++ b/test/components/cards/lCardHeader.spec.ts
@@ -40,9 +40,23 @@ describe('LCardHeader component', () => {
     expect(description().exists()).toBeTruthy()
     expect(description().text()).toBe('Descrição cabeçalho Card')
   })
+})
+
+describe('LCardHeader component rendering items when generateId props true', () => {
+  let cardHeader: Wrapper<LCardHeader>
+
+  beforeAll(() => {
+    cardHeader = mount(LCardHeader, {
+      ...defaultParams,
+      propsData: {
+        title: 'Titulo Cabeçalho Card',
+        generateId: true
+      }
+    })
+  })
 
   it('should return slugged id with prefix when using idToSlug method', async () => {
-    const expansionHeadersWithId = () => cardHeader.findAll('#card-titulo-cabecalho-card')
+    const expansionHeadersWithId = () => cardHeader.findAll('#cardHeader-titulo-cabecalho-card')
     await cardHeader.vm.$nextTick()
 
     expect(expansionHeadersWithId().length).toBe(1)

--- a/test/utils/string.spec.ts
+++ b/test/utils/string.spec.ts
@@ -1,0 +1,9 @@
+import { slugify } from '~/utils/string.util'
+
+describe('String utils', () => {
+  it('should test returns from slugify function', () => {
+    const string = 'My String Slug'
+    const sluggedString = slugify(string)
+    expect(sluggedString).toEqual('my-string-slug')
+  })
+})

--- a/utils/string.util.ts
+++ b/utils/string.util.ts
@@ -1,0 +1,17 @@
+export function slugify (string: string) {
+  string = string.replace(/^\s+|\s+$/g, '') // trim
+  string = string.toLowerCase()
+
+  const from = 'àáãäâèéëêìíïîòóöôùúüûñç·/_,:;'
+  const to = 'aaaaaeeeeiiiioooouuuunc------'
+
+  for (let i = 0, l = from.length; i < l; i++) {
+    string = string.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i))
+  }
+
+  string = string.replace(/[^a-z0-9 -]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+
+  return string
+}

--- a/utils/string.util.ts
+++ b/utils/string.util.ts
@@ -1,5 +1,5 @@
 export function slugify (string: string) {
-  string = string.replace(/^\s+|\s+$/g, '') // trim
+  string = string.replace(/^\s+|\s+$/g, '')
   string = string.toLowerCase()
 
   const from = 'àáãäâèéëêìíïîòóöôùúüûñç·/_,:;'


### PR DESCRIPTION
## :package: Conteúdo

- Adição de props para deixar geração de ID condicional
- Implementação de função slugify para gerar id
- Testes unitários
- Documentação

## :heavy_check_mark: Tarefa(s)

- [LOG-16134](https://logcomex.atlassian.net/browse/LOG-16134)

## :eyes: Link da tarefa de code review:

- [LOG-16731](https://logcomex.atlassian.net/browse/LOG-16731)