### PR TITLE
(LOG-16349) Ajustar board que não está responsivo

### DIFF
--- a/docs/stories/components/charts/LLinearChart.stories.js
+++ b/docs/stories/components/charts/LLinearChart.stories.js
@@ -4,23 +4,24 @@ export default {
   title: 'Components/Charts/Primary Bar/Minimized',
   component: LLinearChart,
   argTypes: {
-    data: { control: 'object', description: 'Data object: label, percentage, total, quantity, value' },
+    applyCursorPointer: { control: 'boolean', description: 'Validation to apply css with pointer' },
     colors: { control: 'array', description: 'Colors array (hexadecimal)' },
-    itemsWithoutDetails: { control: 'array', description: 'Receives info about when it should shows details icon' },
-    translationLine: { control: 'object', description: 'Subtitles translation object: value, records, seeMore' },
+    data: { control: 'object', description: 'Data object: label, percentage, total, quantity, value' },
     isExpanded: { control: 'boolean', description: 'Chart expanded: true / Chart minimized: false' },
     isExpandable: { control: 'boolean', description: 'Chart expandable: true / Chart not expandable: false' },
+    itemsWithoutDetails: { control: 'array', description: 'Receives info about when it should shows details icon' },
+    labelMaxLength: {control: 'number', description: 'Max characters allowed to label'},
+    maxQuantity: { action: 'number', description: 'Max items allowed' },
+    showToolTip: { control: 'boolean', description: 'Props to control the visibility of tooltip passed to child components' },
+    translationLine: { control: 'object', description: 'Subtitles translation object: value, records, seeMore' },
     expandList: { action: 'expandList', description: 'Toggle chart expanded when "See more" clicked' },
     eventClick: { action: 'eventClick', description: 'Event emitted when label is clicked' },
-    maxQuantity: { action: 'number', description: 'Max items allowed' },
     scroller: { table: {disable: true} },
     type: { table: {disable: true} },
     loadingExpand: { table: {disable: true} },
     generateColor: { table: {disable: true} },
     isTagChart:  {table: {disable: true} },
-    sectionAfterValue: { description: 'Slot can show extra content and return info to parent components to show more details' },
-    applyCursorPointer: { control: 'boolean', description: 'Validation to apply css with pointer' },
-    showToolTip: { description: 'Props to control the visibility of tooltip passed to child components' }
+    sectionAfterValue: { description: 'Slot can show extra content and return info to parent components to show more details' }
   },
 };
 

--- a/src/components/charts/LLinearChart.vue
+++ b/src/components/charts/LLinearChart.vue
@@ -19,6 +19,7 @@
             :translation-line="translationLine"
             :items-without-details="itemsWithoutDetails"
             :show-tool-tip="showToolTip"
+            :label-max-length="labelMaxLength"
             @expand="expandList"
             @eventClick="eventClick"
           >
@@ -101,6 +102,10 @@ export default {
     showToolTip: {
       type: Boolean,
       default: false
+    },
+    labelMaxLength: {
+      type: Number,
+      default: 23
     }
   },
   methods: {

--- a/src/components/charts/LLinearChartLine.vue
+++ b/src/components/charts/LLinearChartLine.vue
@@ -31,7 +31,9 @@
               </span>
             </template>
             <template v-else>
-              {{ isTruncated ? `${data.label.substring(0, labelMaxLength)}...` : data.label }}
+              <span class="LLinearChartLine__label">
+                {{ isTruncated ? `${data.label.substring(0, labelMaxLength)}...` : data.label }}
+              </span>
             </template>
             <slot
               v-if="!itemsWithoutDetails.includes(data.label)"

--- a/src/components/charts/LLinearChartLine.vue
+++ b/src/components/charts/LLinearChartLine.vue
@@ -184,7 +184,7 @@ export default {
   },
   computed: {
     isTruncated () {
-      return this.data.label.length >= this.labelMaxLength
+      return this.data.label.length > this.labelMaxLength
     },
     dataLabel () {
        return this.isTruncated ? `${this.data.label.substring(0, this.labelMaxLength)}...` : this.data.label

--- a/src/components/charts/LLinearChartLine.vue
+++ b/src/components/charts/LLinearChartLine.vue
@@ -27,12 +27,12 @@
                 class="LLinearChartLine__cursor_pointer"
                 @click="eventClick(data.label)"
               >
-                {{ isTruncated ? `${data.label.substring(0, labelMaxLength)}...` : data.label }}
+                {{ dataLabel }}
               </span>
             </template>
             <template v-else>
               <span class="LLinearChartLine__label">
-                {{ isTruncated ? `${data.label.substring(0, labelMaxLength)}...` : data.label }}
+                {{ dataLabel }}
               </span>
             </template>
             <slot
@@ -185,6 +185,9 @@ export default {
   computed: {
     isTruncated () {
       return this.data.label.length >= this.labelMaxLength
+    },
+    dataLabel () {
+       return this.isTruncated ? `${this.data.label.substring(0, this.labelMaxLength)}...` : this.data.label
     },
     showQuantity () {
       return this.lastItem ? `(${this.data.quantity})` : ''

--- a/src/components/charts/LLinearChartLine.vue
+++ b/src/components/charts/LLinearChartLine.vue
@@ -2,6 +2,7 @@
   <v-container class="LLinearChartLine pa-0">
     <div class="d-flex justify-space-between col-12 ma-0 pa-0">
       <v-tooltip
+        :disabled="!isTruncated"
         bottom
         content-class="customTooltip pa-0"
       >
@@ -26,11 +27,11 @@
                 class="LLinearChartLine__cursor_pointer"
                 @click="eventClick(data.label)"
               >
-                {{ data.label }}
+                {{ isTruncated ? `${data.label.substring(0, labelMaxLength)}...` : data.label }}
               </span>
             </template>
             <template v-else>
-              {{ data.label }}
+              {{ isTruncated ? `${data.label.substring(0, labelMaxLength)}...` : data.label }}
             </template>
             <slot
               v-if="!itemsWithoutDetails.includes(data.label)"
@@ -70,7 +71,7 @@
         >
           <v-col
             v-if="data.value !== null"
-            class="pl-2 py-0 pr-0 ml-n8 LLinearChartLine__result__value--first"
+            class="py-0 LLinearChartLine__result__value--first"
           >
             <v-tooltip
               bottom
@@ -89,13 +90,13 @@
               </span>
             </v-tooltip>
           </v-col>
-
+          <span style="marginRight: -4%; marginLeft: -4%">{{ showPartition(data) }}</span>
           <v-col
             v-if="data.total !== null"
-            class="py-0 pl-3 LLinearChartLine__result__value--second"
+            class="py-0 LLinearChartLine__result__value--second"
           >
             <span>
-              {{ showPartition(data) }}{{ translationLine.records || $t('ayla.records') }}: {{ data.total }}
+              {{ translationLine.records || $t('ayla.records') }}: {{ data.total }}
             </span>
           </v-col>
         </v-row>
@@ -166,6 +167,10 @@ export default {
       type: Array,
       default: () => []
     },
+    labelMaxLength: {
+      type: Number,
+      default: 23
+    },
     applyCursorPointer: {
       type: Boolean,
       default: false
@@ -176,6 +181,9 @@ export default {
     }
   },
   computed: {
+    isTruncated () {
+      return this.data.label.length >= this.labelMaxLength
+    },
     showQuantity () {
       return this.lastItem ? `(${this.data.quantity})` : ''
     }
@@ -200,7 +208,6 @@ export default {
     white-space: nowrap;
     overflow: hidden;
     max-width: 100%;
-    text-overflow: ellipsis;
     width: 0;
     flex-basis: 100%;
   }
@@ -223,6 +230,13 @@ export default {
     color: $silver;
     white-space: nowrap;
     min-width: 250px;
+    padding-left: 2%;
+  }
+  .LLinearChartLine__result__value--first{
+    flex-grow: 0;
+  }
+  .LLinearChartLine__result__value--second{
+    flex-grow: 0;
   }
   .LLinearChartLine__expand {
     @extend .globalLink;

--- a/test/components/charts/lLinearChart.spec.ts
+++ b/test/components/charts/lLinearChart.spec.ts
@@ -80,7 +80,7 @@ describe('linearChart component', () => {
 
     expect(linearChart.find('.LLinearChartLine__expand').text()).toBe('seeMoreTest')
     expect(linearChart.find('.LLinearChartLine__result__value--first').text()).toBe('valueTest: 16.535.343,00')
-    expect(linearChart.find('.LLinearChartLine__result__value--second').text()).toBe('| recordTest: 360')
+    expect(linearChart.find('.LLinearChartLine__result__value--second').text()).toBe('recordTest: 360')
   })
 
   it('emit expand list', async () => {
@@ -95,5 +95,11 @@ describe('linearChart component', () => {
 
   it('checks default value for props showToolTip', async () => {
     expect(linearChart.vm.showToolTip).toBe(false)
+  })
+
+  it('respects max length allowed for labels', async () => {
+    linearChart.setProps({labelMaxLength: 5})
+    await linearChart.vm.$nextTick()
+    expect(linearChart.find('.LLinearChartLine__label').text()).toBe('ASCEN...')
   })
 })


### PR DESCRIPTION
## :package: Conteúdo

- Removendo classes de espaçamento desnecessárias
- Deixando os itens da linha mais próximos (segundo protótipo)
- Adicionando prop pra limitar a qtde de caracteres que uma label pode ter
- Atualização da documentação e testes unitários

## :heavy_check_mark: Tarefa(s)

- LOG-17579
- LOG-17611
- LOG-17656
- LOG-17655

## :eyes: Tarefa de Code Review (CR)

- LOG-17583
