### PR TITLE
(LOG-22722) - Correção para fechar modal ao clicar do lado de fora

### DIFF
--- a/src/components/modal/LModal.vue
+++ b/src/components/modal/LModal.vue
@@ -4,7 +4,7 @@
     :max-width="maxWidth"
     overlay-color="overlayColor"
     :persistent="true"
-    @click:outside="closeOnOutsideClick ? closeModal : ''"
+    @click:outside="handleClickOutside"
   >
     <v-card
       class="modal"
@@ -150,6 +150,11 @@ export default {
     },
     clear () {
       this.$emit('clear')
+    },
+    handleClickOutside () {
+      if (this.closeOnOutsideClick){
+        this.closeModal()
+      }
     }
   }
 }

--- a/test/components/modal/LModal.spec.ts
+++ b/test/components/modal/LModal.spec.ts
@@ -20,6 +20,9 @@ describe('LModal component', () => {
     modal.setProps({dialog: true})
   })
 
+  afterEach(() =>{
+    jest.clearAllMocks()
+  })
   it('rendering as confirmational modal (default)', () => {
     expect(modal.props('modalType')).toEqual({confirmational: true})
     expect(modal.find('.modal__button--confirm').exists()).toBe(true)
@@ -70,7 +73,7 @@ describe('LModal component', () => {
     dialog().vm.$emit('click:outside')
     await modal.vm.$nextTick()
 
-    expect(spyCloseModal).toHaveBeenCalledTimes(2)
+    expect(spyCloseModal).toHaveBeenCalledTimes(1)
     expect(modal.emitted().close).toBeTruthy()
   })
 
@@ -82,6 +85,6 @@ describe('LModal component', () => {
     dialog().vm.$emit('click:outside')
     await modal.vm.$nextTick()
 
-    expect(spyCloseModal).toHaveBeenCalledTimes(2)
+    expect(spyCloseModal).toHaveBeenCalledTimes(0)
   })
 })


### PR DESCRIPTION
## :package: Conteúdo

- Correção para emitir o evento de fechar corretamente caso clique ao lado de fora
- Teste unitário

## :heavy_check_mark: Tarefa(s)

- LOG-26225


## :eyes: Tarefa de Code Review (CR)

- LOG-23547

