### PR TITLE
(LOG-32853) - Corrigido tag saindo do input ao ter varias

### DIFF
--- a/docs/stories/components/inputs/LInputTag.stories.js
+++ b/docs/stories/components/inputs/LInputTag.stories.js
@@ -32,3 +32,10 @@ Expandable.args = {
   value: ['First item', 'Second item', 'Third item'],
   expand: true
 };
+
+export const ShowDetails = Template.bind({});
+ShowDetails.args = {
+  value: ['First item', 'Second item', 'Third item'],
+  expand: false,
+  hideDetails: false
+};

--- a/src/components/inputs/LInputTag.vue
+++ b/src/components/inputs/LInputTag.vue
@@ -47,7 +47,7 @@ export default {
   computed: {
     classInputTag () {
       return {
-        'hide-details': this.hideDetails
+        'LInputTag--hideDetails': this.hideDetails
       }
     },
     inputValue: {
@@ -68,11 +68,12 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.LInputTag.hide-details {
+.LInputTag--hideDetails {
   ::v-deep {
     @extend .commonCombobox;
   }
 }
+
 .LInputTag {
   ::v-deep {
     @extend .commonInput;

--- a/src/components/inputs/LInputTag.vue
+++ b/src/components/inputs/LInputTag.vue
@@ -47,7 +47,7 @@ export default {
   computed: {
     classInputTag () {
       return {
-        'hide-details': !this.hideDetails
+        'hide-details': this.hideDetails
       }
     },
     inputValue: {

--- a/test/components/inputs/lInputTag.spec.ts
+++ b/test/components/inputs/lInputTag.spec.ts
@@ -1,6 +1,7 @@
 import { mount, Wrapper } from '@vue/test-utils'
 import { initSetupComponent } from '~/test/utils.setup'
 import LInputTag from '~/src/components/inputs/LInputTag.vue'
+import { hasUncaughtExceptionCaptureCallback } from 'process'
 
 
 const setupDefault = initSetupComponent()
@@ -21,7 +22,7 @@ describe('inputTag component', () => {
     expect(inputTag.exists()).toBe(true)
   })
 
-  it('show expand item', async () => {
+  it('shows expand item', async () => {
     inputTag.setProps({ expand: true })
     const iconAppendOuter = () => inputTag.find('.v-input__append-outer')
 
@@ -34,6 +35,21 @@ describe('inputTag component', () => {
     await inputTag.vm.$nextTick()
 
     expect(inputTag.emitted().clickAppendOuter).toBeTruthy()
+  })
 
+  it('emits input on type value and keydown enter', async () => {
+    const inputElement = () => inputTag.find('input')
+    await inputElement().setValue('value')
+    await inputElement().trigger('keydown.enter')
+    expect(inputTag.emitted().input[0]).toEqual([['value']])
+  })
+
+  it('renders class only hideDetails is true', async () => {
+    // default is hideDetails true
+    expect(inputTag.find('.hide-details').exists()).toBe(true)
+
+    await inputTag.setProps({ hideDetails: false })
+
+    expect(inputTag.find('.hide-details').exists()).toBe(false)
   })
 })

--- a/test/components/inputs/lInputTag.spec.ts
+++ b/test/components/inputs/lInputTag.spec.ts
@@ -1,7 +1,6 @@
 import { mount, Wrapper } from '@vue/test-utils'
 import { initSetupComponent } from '~/test/utils.setup'
 import LInputTag from '~/src/components/inputs/LInputTag.vue'
-import { hasUncaughtExceptionCaptureCallback } from 'process'
 
 
 const setupDefault = initSetupComponent()
@@ -46,10 +45,10 @@ describe('inputTag component', () => {
 
   it('renders class only hideDetails is true', async () => {
     // default is hideDetails true
-    expect(inputTag.find('.hide-details').exists()).toBe(true)
+    expect(inputTag.find('.LInputTag--hideDetails').exists()).toBe(true)
 
     await inputTag.setProps({ hideDetails: false })
 
-    expect(inputTag.find('.hide-details').exists()).toBe(false)
+    expect(inputTag.find('.LInputTag--hideDetails').exists()).toBe(false)
   })
 })


### PR DESCRIPTION
## :package: Conteúdo

- Corrigido tag saindo do input ao ter varias

## :heavy_check_mark: Tarefa(s)

- LOG-32853

## :eyes: Tarefa de Code Review (CR)

- LOG-33015
