### PR TITLE
(LOG-33742) - Está sendo possível selecionar datas inferior 2011

### DIFF
--- a/src/components/inputs/LDatePickerDay.vue
+++ b/src/components/inputs/LDatePickerDay.vue
@@ -405,9 +405,6 @@ export default {
         max: maxCalculatedRangePropFormatted
       }
     },
-    getRangeDateByLimit() {
-
-    },
     hoverDate(date) {
       this.temporaryDate = date
     },

--- a/src/components/inputs/LDatePickerDay.vue
+++ b/src/components/inputs/LDatePickerDay.vue
@@ -388,9 +388,19 @@ export default {
       this.rangeLimit.max = null
     },
     getDateLimitRange(currentDate, quantity, unit) {
+      const minCalculatedRangeProp = dayjs(currentDate).subtract(quantity, unit)
+      const maxCalculatedRangeProp = dayjs(currentDate).add(quantity, unit)
+
+      if (this.limit) {
+        return {
+          min: minCalculatedRangeProp.isBefore(dayjs(this.limit.min)) ? this.limit.min : minCalculatedRangeProp.format('YYYY-MM-DD'),
+          max: maxCalculatedRangeProp.isAfter(dayjs(this.limit.max)) ? this.limit.max : maxCalculatedRangeProp.format('YYYY-MM-DD')
+        }
+      }
+
       return {
-        min: dayjs(currentDate).subtract(quantity, unit).format('YYYY-MM-DD'),
-        max: dayjs(currentDate).add(quantity, unit).format('YYYY-MM-DD')
+        min: minCalculatedRangeProp.format('YYYY-MM-DD'),
+        max: maxCalculatedRangeProp.format('YYYY-MM-DD')
       }
     },
     hoverDate(date) {

--- a/src/components/inputs/LDatePickerDay.vue
+++ b/src/components/inputs/LDatePickerDay.vue
@@ -390,18 +390,23 @@ export default {
     getDateLimitRange(currentDate, quantity, unit) {
       const minCalculatedRangeProp = dayjs(currentDate).subtract(quantity, unit)
       const maxCalculatedRangeProp = dayjs(currentDate).add(quantity, unit)
+      const minCalculatedRangePropFormatted = minCalculatedRangeProp.format('YYYY-MM-DD')
+      const maxCalculatedRangePropFormatted = maxCalculatedRangeProp.format('YYYY-MM-DD')
 
       if (this.limit) {
         return {
-          min: minCalculatedRangeProp.isBefore(dayjs(this.limit.min)) ? this.limit.min : minCalculatedRangeProp.format('YYYY-MM-DD'),
-          max: maxCalculatedRangeProp.isAfter(dayjs(this.limit.max)) ? this.limit.max : maxCalculatedRangeProp.format('YYYY-MM-DD')
+          min: minCalculatedRangeProp.isBefore(dayjs(this.limit.min)) ? this.limit.min : minCalculatedRangePropFormatted,
+          max: maxCalculatedRangeProp.isAfter(dayjs(this.limit.max)) ? this.limit.max : maxCalculatedRangePropFormatted
         }
       }
 
       return {
-        min: minCalculatedRangeProp.format('YYYY-MM-DD'),
-        max: maxCalculatedRangeProp.format('YYYY-MM-DD')
+        min: minCalculatedRangePropFormatted,
+        max: maxCalculatedRangePropFormatted
       }
+    },
+    getRangeDateByLimit() {
+
     },
     hoverDate(date) {
       this.temporaryDate = date

--- a/test/components/inputs/lDatePickerDay.spec.ts
+++ b/test/components/inputs/lDatePickerDay.spec.ts
@@ -13,6 +13,24 @@ const updatedDateLimit = {
 }
 
 const setupDefault = initSetupComponent()
+const mountWithoutLimit = () => {
+  return mount(LDatePickerDay, {
+    ...setupDefault,
+    propsData: {
+      value: ['2020-03-01', '2020-05-31']
+    },
+    data() {
+      return {
+        monthsPeriod: ['2020-03-01', '2020-05-31']
+      }
+    },
+    computed: {
+      i18nLocale() {
+        return 'pt'
+      }
+    }
+  })
+}
 const defaultParams = {
   ...setupDefault,
   propsData: {
@@ -96,7 +114,10 @@ describe('datePicker component', () => {
   })
 
   it('Check date limit by years range', async () => {
-    datePicker.setProps({ rangeYears: 1 , rangeDays: null})
+    datePicker = mountWithoutLimit()
+    datePicker.setProps({ rangeYears: 1 })
+    const activator = () => datePicker.find('.activator')
+    activator().trigger('click')
 
     await datePicker.vm.$nextTick()
 
@@ -125,6 +146,27 @@ describe('datePicker component', () => {
     await datePicker.vm.$nextTick()
 
     expect(datePicker.vm.rangeLimit).toEqual({"max": "2020-04-11", "min": "2020-03-22"})
+  })
+
+  it('should limit select range with limit prop over rangeDays and rangeYears props', async () => {
+    datePicker.setProps({
+      limit: {
+        min: '2020-03-30',
+        max: '2020-04-30'
+      }
+    })
+
+    await datePicker.vm.$nextTick()
+
+    const datepickers = () => datePicker.findAllComponents({ name: 'v-date-picker' })
+    const firstDatepicker = () => datepickers().at(0)
+    const dayPicker = () => firstDatepicker().find('tbody tr td .v-btn')
+    expect(dayPicker().text()).toBe('1')
+    dayPicker().trigger('click')
+
+    await datePicker.vm.$nextTick()
+
+    expect(datePicker.vm.rangeLimit).toEqual({"max": "2020-04-11", "min": "2020-03-30"})
   })
 
   it('check multiple click in same date', async () => {


### PR DESCRIPTION
## :package: Conteúdo

- Ajustado comportamente do datepicker para respeitar o limit passado como prop ao invés de sobrescrever com o range calcúlado usando outras props (rangeDays e rangeYears)

## :heavy_check_mark: Tarefa(s)

- LOG-32513

## :eyes: Tarefa de Code Review (CR)
- LOG-32820