### PR TITLE
(LOG-35830) Removendo padding a mais do LInputLoaded e LInputTag

### DIFF
--- a/src/components/inputs/LInputLoaded.vue
+++ b/src/components/inputs/LInputLoaded.vue
@@ -256,9 +256,6 @@ export default {
   .v-input__slot {
     min-height: 25px !important;
   }
-  .v-select__slot {
-    padding: 0 12px;
-  }
   .v-icon {
     height: 20px;
   }

--- a/src/components/inputs/LInputTag.vue
+++ b/src/components/inputs/LInputTag.vue
@@ -140,9 +140,6 @@ export default {
   .v-input__slot {
     min-height: 25px !important;
   }
-  .v-select__slot {
-    padding: 0 12px;
-  }
   .v-input__append-outer {
     margin: 0 !important;
   }


### PR DESCRIPTION
## :package: Conteúdo

- Padding de 12px já estava aplicado, e por algum motivo, estava aplicando +12.

## :heavy_check_mark: Tarefa(s)

- LOG-35830

## :eyes: Tarefa de Code Review (CR)

- LOG-35834
