### PR TITLE
(LOG-37060) Ajustando acessibilidade dos inputs

### DIFF
--- a/docs/stories/components/inputs/LCombobox.stories.js
+++ b/docs/stories/components/inputs/LCombobox.stories.js
@@ -54,7 +54,8 @@ export const DefaultLoading = Template.bind({});
 DefaultLoading.args = {
   ...Default.args,
   loading: true,
-  disabled: true
+  disabled: true,
+  id: 'defaultLoading'
 }
 
 export const DefaultLoaded = Template.bind({});

--- a/docs/stories/components/inputs/LSelect.stories.js
+++ b/docs/stories/components/inputs/LSelect.stories.js
@@ -54,7 +54,8 @@ Default.args = {
 export const DefaultLarge = Template.bind({});
 DefaultLarge.args = {
   ...Default.args,
-  large: true
+  large: true,
+  id: 'defaultLarge',
 }
 
 export const DefaultSmall = Template.bind({});

--- a/docs/stories/components/inputs/LTextField.stories.js
+++ b/docs/stories/components/inputs/LTextField.stories.js
@@ -51,7 +51,8 @@ Default.args = {
 export const DefaultLarge = Template.bind({});
 DefaultLarge.args = {
   ...Default.args,
-  large: true
+  large: true,
+  id: 'defaultLarge'
 }
 
 export const DefaultSmall = Template.bind({});

--- a/src/components/inputs/LCombobox.vue
+++ b/src/components/inputs/LCombobox.vue
@@ -37,6 +37,7 @@ import { getInputHeight } from '~/utils/size.util'
 
 export default {
   name: 'LCombobox',
+  inheritAttrs: false,
   props: {
     allowHeightGrow: Boolean,
     dropdownIcon: Boolean,

--- a/src/components/inputs/LSelect.vue
+++ b/src/components/inputs/LSelect.vue
@@ -37,6 +37,7 @@ import { getInputHeight } from '~/utils/size.util'
 
 export default {
   name: 'LSelect',
+  inheritAttrs: false,
   props: {
     allowHeightGrow: Boolean,
     dropdownIcon: {

--- a/src/components/inputs/LTextField.vue
+++ b/src/components/inputs/LTextField.vue
@@ -5,6 +5,7 @@
       v-bind="$attrs"
       class="LTextField__input"
       :class="inputClass"
+      :aria-label="$attrs.label"
       v-on="$listeners"
     >
       <template
@@ -32,6 +33,7 @@ import { getInputHeight } from '~/utils/size.util'
 
 export default {
   name: 'LTextField',
+  inheritAttrs: false,
   props: {
     large: Boolean,
     small: Boolean

--- a/test/components/inputs/lCombobox.spec.ts
+++ b/test/components/inputs/lCombobox.spec.ts
@@ -96,4 +96,10 @@ describe('LCombobox', () => {
     expect(screen.getByText('Fourth item')).toBeInTheDocument()
     expect(screen.getByText('Fifth item')).toBeInTheDocument()
   })
+
+  it('finds only one combobox by id', () => {
+    const { container } = renderComponent(DefaultLoading())
+
+    expect(container.querySelectorAll('#defaultLoading').length).toBe(1)
+  })
 })

--- a/test/components/inputs/lSelect.spec.ts
+++ b/test/components/inputs/lSelect.spec.ts
@@ -68,4 +68,10 @@ describe('LSelect', () => {
     expect(icon).toBeInTheDocument()
     expect(icon).toBeVisible()
   })
+
+  it('finds only one select by id', () => {
+    const { container } = renderComponent(DefaultLarge())
+
+    expect(container.querySelectorAll('#defaultLarge').length).toBe(1)
+  })
 })

--- a/test/components/inputs/lTextField.spec.ts
+++ b/test/components/inputs/lTextField.spec.ts
@@ -39,4 +39,16 @@ describe('LTextField', () => {
     expect(icon).toBeInTheDocument()
     expect(icon).toBeVisible()
   })
+
+  it('finds textfield with id through its label', () => {
+    renderComponent(DefaultLarge())
+
+    expect(screen.getByLabelText('Label')).toBeInTheDocument()
+  })
+
+  it('finds only one textfield by id', () => {
+    const { container } = renderComponent(DefaultLarge())
+
+    expect(container.querySelectorAll('#defaultLarge').length).toBe(1)
+  })
 })


### PR DESCRIPTION
## :package: Conteúdo

- Adição inheritAttrsFalse para prevenir que tenham atributos em duplicidade i.e. ids
- Adição aria-label ao LTextField para que ele possa ser encontrado pela label mesmo recebendo id

## :heavy_check_mark: Tarefa(s)

- LOG-37060

## :eyes: Tarefa de Code Review (CR)

- LOG-42470
