### PR TITLE
LOG-43589 - Adequado ícones de 'close' e 'link' para aparecerem na mesma tag

### DIFF
--- a/src/components/tags/LTag.vue
+++ b/src/components/tags/LTag.vue
@@ -12,6 +12,13 @@
       @click:close="closeTag(text)"
       v-on="$listeners"
     >
+      <v-icon
+        v-if="link && close"
+        left
+        class="tag__link"
+      >
+        {{ customIcon || 'mdi-open-in-new' }}
+      </v-icon>
       {{ text }}
       <span
         v-if="number !== null && number !== undefined"
@@ -20,7 +27,7 @@
         {{ number }}
       </span>
       <v-icon
-        v-if="link"
+        v-if="link && !close"
         right
         class="tag__link"
       >

--- a/test/components/tags/lTag.spec.ts
+++ b/test/components/tags/lTag.spec.ts
@@ -43,6 +43,8 @@ describe('Tag component', () => {
 
     expect(icons.length).toBe(2)
     expect(icons.at(0).contains('.tag__link')).toBe(true)
+    expect(icons.at(0).contains('.v-icon--left')).toBe(true)
     expect(icons.at(1).contains('.v-chip__close')).toBe(true)
+    expect(icons.at(1).contains('.v-icon--right')).toBe(true)
   })
 })

--- a/test/components/tags/lTag.spec.ts
+++ b/test/components/tags/lTag.spec.ts
@@ -34,4 +34,15 @@ describe('Tag component', () => {
     expect(tagLink().exists()).toBeTruthy()
     expect(chip().props().color).toBeTruthy()
   })
+
+  it('Test rendering with link and close icons', async () => {
+    tag.setProps({ text: 'texto', link: true, close: true })
+    await tag.vm.$nextTick()
+
+    const icons = tag.findAll('.v-icon')
+
+    expect(icons.length).toBe(2)
+    expect(icons.at(0).contains('.tag__link')).toBe(true)
+    expect(icons.at(1).contains('.v-chip__close')).toBe(true)
+  })
 })


### PR DESCRIPTION
## :package: Conteúdo

- Adequado ícones de 'close' e 'link' para aparecerem na mesma tag (quando for solicitado ambos)
- Adicionado teste unitário

## :heavy_check_mark: Tarefa(s)

- LOG-38043

## :eyes: Tarefa de Code Review (CR)

- LOG-43597
