### PR TITLE
(LOG-47259) Mecanismo de enabledPeriods no datepicker

### DIFF
--- a/docs/stories/components/inputs/LDatePickerMonth.stories.js
+++ b/docs/stories/components/inputs/LDatePickerMonth.stories.js
@@ -28,6 +28,10 @@ export default {
       control: 'text',
       description: 'Locale of the datepicker'
     },
+    enabledPeriods: {
+      control: 'array',
+      description: 'Enabled periods chips on datepicker'
+    },
     dropdownIcon: { control: 'boolean', description: 'Toggles dropdown icon visibility' },
     bordered: { control: 'boolean', description: 'Toggles datepicker border and adds LDatePickerMonth--bordered class' },
     borderColor: { control: 'color', description: 'Color of the border' },
@@ -95,4 +99,10 @@ export const Bordered = Template.bind({});
 Bordered.args = {
   ...Filled.args,
   bordered: true
+}
+
+export const DisabledPeriods = Template.bind({})
+DisabledPeriods.args = {
+  ...Filled.args,
+  enabledPeriods: []
 }

--- a/src/components/inputs/LDatePickerMonth.vue
+++ b/src/components/inputs/LDatePickerMonth.vue
@@ -71,6 +71,7 @@
             label
             class="justify-center"
             :class="{ 'datepicker__calendar__period__chip--active' : periodChip === index }"
+            :disabled="!enabledPeriods.includes(index)"
             @click="periodChip = index"
           >
             <span
@@ -120,6 +121,15 @@ export default {
     borderColor: {
       type: String,
       default: '#5C068C'
+    },
+    enabledPeriods: {
+      type: Array,
+      default: () => [
+        'last_3_months',
+        'last_6_months', 
+        'last_9_months', 
+        'last_12_months'
+      ]
     },
     bordered: Boolean
   },

--- a/test/components/inputs/lDatePickerMonth.spec.ts
+++ b/test/components/inputs/lDatePickerMonth.spec.ts
@@ -74,4 +74,11 @@ describe('datePicker component', () => {
 
     expect( datePicker.find('.LDatePickerMonth--bordered').exists()).toBe(true)
   })
+
+  it('toggles enabledPeriods disabled', async () => {
+    datePicker.setProps({ enabledPeriods: ['last_6_months', 'last_9_months', 'last_12_months'] })
+    await datePicker.vm.$nextTick()
+
+    expect(datePicker.findAll('.v-chip--disabled').length).toBe(1)
+  })
 })

--- a/test/components/inputs/lDatePickerMonth.spec.ts
+++ b/test/components/inputs/lDatePickerMonth.spec.ts
@@ -17,8 +17,9 @@ const defaultParams = {
   ...setupDefault,
   propsData: {
     limit: {
-      ...initialDateLimit
+      ...initialDateLimit,
     },
+    enabledPeriods: ['last_6_months', 'last_9_months', 'last_12_months'],
     value: ['2020-03', '2020-05'],
     monthsList: ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun']
   },
@@ -75,10 +76,7 @@ describe('datePicker component', () => {
     expect( datePicker.find('.LDatePickerMonth--bordered').exists()).toBe(true)
   })
 
-  it('toggles enabledPeriods disabled', async () => {
-    datePicker.setProps({ enabledPeriods: ['last_6_months', 'last_9_months', 'last_12_months'] })
-    await datePicker.vm.$nextTick()
-
+  it('renders right amount of disabled periods', async () => {
     expect(datePicker.findAll('.v-chip--disabled').length).toBe(1)
   })
 })


### PR DESCRIPTION
## :package: Conteúdo

- Mecanismo para tornar alguns períodos disabled se naõ estiverem presentes no array de prop

## :heavy_check_mark: Tarefa(s)

- LOG-47259

## :eyes: Tarefa de Code Review (CR)

- LOG-47574
