### PR TITLE
(LOG-48782) Corrigindo conflito vModel com value prop

### DIFF
--- a/docs/stories/components/inputs/LCheckboxNew.stories.js
+++ b/docs/stories/components/inputs/LCheckboxNew.stories.js
@@ -4,8 +4,23 @@ export default {
   title: 'Components/Inputs/Checkbox',
   component: LCheckboxNew,
   argTypes: {
-    value: { control: 'text', description: 'Input content' },
-    color: { control: 'color', description: 'Content color' },
+    value: { 
+      control: 'boolean', 
+      description: `Toggles checkbox state. This prop is used to create an inner v-model so you can retrieve its value`
+    },
+    itemValue: { 
+      description: `Toggles checkbox state. This prop value is propagated to the value prop from VCheckbox, 
+      so instead of setting value="someValue" on your component, use item-value="someValue". It can receive any type`
+    },
+    label: {
+      table: { disable: true }
+    },
+    color: { 
+      table: { disable: true }
+     },
+    input: {  
+      table: { disable: true }
+    }
   },
 };
 
@@ -13,16 +28,40 @@ export default {
 const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { LCheckboxNew },
-  template: `<l-checkbox-new v-bind="$props"></l-checkbox-new>`,
+  template: `<l-checkbox-new v-bind="$props"></l-checkbox-new>`
 });
+
+const TemplateMultipleCheckboxes = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { LCheckboxNew },
+  template: `
+    <div>
+      <l-checkbox-new 
+        v-bind="$props" 
+        v-for="checkbox in 3"
+        :key="checkbox"
+      >
+      </l-checkbox-new>
+    </div>
+  `
+});
+
 
 export const Default = Template.bind({});
 Default.args = {
   value: false,
+  label: 'Checkbox'
 };
 
 export const WithColor = Template.bind({});
 WithColor.args = {
   value: true,
+  label: 'Checkbox',
   color: '#f2f'
+};
+
+export const MultipleCheckboxes = TemplateMultipleCheckboxes.bind({},);
+MultipleCheckboxes.args = {
+  label: 'Checkbox',
+  itemValue: 'Checkbox value'
 };

--- a/src/components/inputs/LCheckboxNew.vue
+++ b/src/components/inputs/LCheckboxNew.vue
@@ -1,8 +1,9 @@
 <template>
   <v-checkbox
     v-model="inputValue"
-    class="LCheckbox"
     v-bind="$attrs"
+    :value="itemValue"
+    class="LCheckbox"
     v-on="$listeners"
   />
 </template>
@@ -15,6 +16,10 @@ export default {
       type: Boolean,
       default: null
     },
+    itemValue: {
+      type: null,
+      default: null
+    }
   },
   computed: {
     inputValue: {

--- a/test/components/inputs/lCheckboxNew.spec.ts
+++ b/test/components/inputs/lCheckboxNew.spec.ts
@@ -4,7 +4,7 @@ import { composeStories } from '@storybook/testing-vue'
 import { renderComponent } from '~/test/utils.setup.testingLibrary'
 import * as stories from '~/docs/stories/components/inputs/LCheckboxNew.stories'
 
-const { Default, WithColor } = composeStories(stories)
+const { Default, WithColor, MultipleCheckboxes } = composeStories(stories)
 
 describe('LCheckboxNew', () => {
   it('renders component unchecked', () => {
@@ -30,5 +30,19 @@ describe('LCheckboxNew', () => {
 
     expect(lCheckboxNew).toHaveStyle({ color: 'rgb(255, 34, 255);' })
     expect(lCheckboxNew).toBeChecked()
+  })
+
+  it('renders and toggles multiple checkboxes', async () => {
+    renderComponent(MultipleCheckboxes())
+
+    let checkboxes = screen.getAllByRole('checkbox')
+    checkboxes.forEach(checkbox => expect(checkbox).not.toBeChecked())
+
+    await userEvent.click(checkboxes[0])
+
+    expect(checkboxes[0]).toBeChecked()
+
+    checkboxes = checkboxes.slice(1)
+    checkboxes.forEach(checkbox => expect(checkbox).not.toBeChecked())
   })
 })


### PR DESCRIPTION
## :package: Conteúdo

- A prop "value" usada para fazer o v-model do LCheckboxNew estava conflitando com a prop "value" do Vuetify. Criei uma nova pra propagar a info pro Vuetify e atualizei a doc e teste unitário.

## :heavy_check_mark: Tarefa(s)

- LOG-48782

## :eyes: Tarefa de Code Review (CR)

- LOG-49275
