### PR TITLE
(LOG-72571) - Correção do DatePickerMonth quando lida com data apenas de ano e mês.

### DIFF
--- a/docs/stories/components/inputs/LDatePickerMonth.stories.js
+++ b/docs/stories/components/inputs/LDatePickerMonth.stories.js
@@ -56,9 +56,9 @@ const Template = (args, { argTypes }) => ({
   components: { LDatePickerMonth },
   template: `
     <l-date-picker-month
-      v-model='date' 
-      v-bind='$props' 
-      style='max-width: 300px;' 
+      v-model='date'
+      v-bind='$props'
+      style='max-width: 300px;'
     />
   `
 })
@@ -80,6 +80,29 @@ Default.args = {
     'Novembro',
     'Dezembro'
   ]
+}
+
+export const DefaultFilledWithYearMonth = Template.bind({});
+DefaultFilledWithYearMonth.args = {
+  limit: { min: '2020-01', max: '2021-12' },
+  monthsList: [
+    'Janeiro',
+    'Fevereiro',
+    'Março',
+    'Abril',
+    'Maio',
+    'Junho',
+    'Julho',
+    'Agosto',
+    'Setembro',
+    'Outubro',
+    'Novembro',
+    'Dezembro'
+  ],
+  date: ['2020-01','2021-02'],
+  value: ['2020-01','2020-12'],
+  bordered: true,
+  locale: 'en'
 }
 
 export const Filled = Template.bind({});

--- a/src/components/inputs/LDatePickerMonth.vue
+++ b/src/components/inputs/LDatePickerMonth.vue
@@ -71,7 +71,6 @@
             v-for="(period, index) of periodsEnum"
             :key="index"
             label
-            :data-testid="period"
             class="justify-center"
             :class="{ 'datepicker__calendar__period__chip--active' : periodChip === index }"
             :disabled="!enabledPeriods.includes(index)"

--- a/src/components/inputs/LDatePickerMonth.vue
+++ b/src/components/inputs/LDatePickerMonth.vue
@@ -240,7 +240,6 @@ export default {
       let { min, max } = this.dateLimit
       max = max.length <= 7 ? max + '-02': max
       min = min.length <= 7 ? min + '-02': min
-      console.log(max, min)
       if (type === 'max') {
         return max
       }

--- a/src/components/inputs/LDatePickerMonth.vue
+++ b/src/components/inputs/LDatePickerMonth.vue
@@ -11,6 +11,7 @@
       <template #activator="{ on }">
         <v-row
           class="pointer mx-0 activator"
+          data-testid="activator"
           v-on="on"
         >
           <v-col
@@ -48,6 +49,7 @@
         no-title
         multiple
         range
+        data-testid="Datepicker"
         :show-current="false"
         :allowed-dates="isDateAllowed"
         :locale="locale"
@@ -69,6 +71,7 @@
             v-for="(period, index) of periodsEnum"
             :key="index"
             label
+            :data-testid="period"
             class="justify-center"
             :class="{ 'datepicker__calendar__period__chip--active' : periodChip === index }"
             :disabled="!enabledPeriods.includes(index)"
@@ -162,7 +165,7 @@ export default {
         return MONTH_PERIODS_VALUES_TO_KEYS[monthsDiff]
       },
       set (periodKey) {
-        const currentDate = new Date(this.dateFilterLimits())
+        const currentDate = new Date(this.dateFilterLimits('max'))
         const currentYear = currentDate.getFullYear()
         const monthsDiff = periodKey.split('_')
         const subtractedDate = new Date(currentYear, currentDate.getMonth() - (parseInt(monthsDiff[1]) - 1))
@@ -234,7 +237,10 @@ export default {
       return new Date().getTime() > new Date(year, month - 1).getTime()
     },
     dateFilterLimits (type) {
-      const { min, max } = this.dateLimit
+      let { min, max } = this.dateLimit
+      max = max.length <= 7 ? max + '-02': max
+      min = min.length <= 7 ? min + '-02': min
+      console.log(max, min)
       if (type === 'max') {
         return max
       }

--- a/src/components/inputs/LDatePickerMonth.vue
+++ b/src/components/inputs/LDatePickerMonth.vue
@@ -162,7 +162,7 @@ export default {
         return MONTH_PERIODS_VALUES_TO_KEYS[monthsDiff]
       },
       set (periodKey) {
-        const currentDate = new Date(this.dateFilterLimits('max'))
+        const currentDate = new Date(this.dateFilterLimits())
         const currentYear = currentDate.getFullYear()
         const monthsDiff = periodKey.split('_')
         const subtractedDate = new Date(currentYear, currentDate.getMonth() - (parseInt(monthsDiff[1]) - 1))

--- a/test/components/inputs/lDatePickerMonth.spec.ts
+++ b/test/components/inputs/lDatePickerMonth.spec.ts
@@ -48,6 +48,25 @@ const defaultParams = {
     }
   }
 }
+
+describe('LDatePickerMonth', () => {
+  it('renders Filled datepicker', async () => {
+    renderComponent(DefaultFilledWithYearMonth())
+
+    await checkDefaultDatepickerOpened()
+    await waitFor(() => expect(screen.getByText('Jan/20 - Fev/21')).toBeInTheDocument())
+  })
+
+  it('renders last 9 months datepicker', async () => {
+    renderComponent(DefaultFilledWithYearMonth())
+
+    await checkDefaultDatepickerOpened()
+    const last9month = screen.getByText('Últimos 9 meses')
+    await userEvent.click(last9month)
+    await waitFor(() => expect(screen.getByText('Abr/21 - Dez/21')).toBeInTheDocument())
+  })
+})
+
 describe('datePicker component', () => {
   addElemWithDataAppToBody()
   let datePicker: Wrapper<LDatePickerMonth>
@@ -96,23 +115,5 @@ describe('datePicker component', () => {
   it('renders period in asc order', async () => {
     const inputText = datePicker.find('.formatted-months').text()
     expect(inputText).toEqual(orderedPeriodAscTextMock)
-  })
-})
-
-describe('LDatePickerMonth', () => {
-  it('renders Filled datepicker', async () => {
-    renderComponent(DefaultFilledWithYearMonth())
-
-    await checkDefaultDatepickerOpened()
-    await waitFor(() => expect(screen.getByText('Jan/20 - Fev/21')).toBeInTheDocument())
-  })
-
-  it('renders last 9 months datepicker', async () => {
-    renderComponent(DefaultFilledWithYearMonth())
-
-    await checkDefaultDatepickerOpened()
-    const last9month = screen.getByTestId('datepickerPeriods.last_9_months')
-    await userEvent.click(last9month)
-    await waitFor(() => expect(screen.getByText('Abr/21 - Dez/21')).toBeInTheDocument())
   })
 })

--- a/test/components/inputs/lDatePickerMonth.spec.ts
+++ b/test/components/inputs/lDatePickerMonth.spec.ts
@@ -12,6 +12,16 @@ const updatedDateLimit = {
   max: '2020-05-31'
 }
 
+const initialDateLimitYearMonth = {
+  min: '2020-03',
+  max: '2020-05'
+}
+
+const updatedDateLimitYearMonth = {
+  min: '2019-03',
+  max: '2020-05'
+}
+
 const orderedPeriodAscTextMock = 'Mar/20 - Mai/20'
 
 const setupDefault = initSetupComponent()
@@ -20,6 +30,28 @@ const defaultParams = {
   propsData: {
     limit: {
       ...initialDateLimit,
+    },
+    enabledPeriods: ['last_6_months', 'last_9_months', 'last_12_months'],
+    value: ['2020-05', '2020-03'],
+    monthsList: ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun']
+  },
+  data () {
+    return {
+      monthsPeriod: ['2020-03', '2020-05']
+    }
+  },
+  computed: {
+    i18nLocale () {
+      return 'pt'
+    }
+  }
+}
+
+const yearAndMothParams = {
+  ...setupDefault,
+  propsData: {
+    limit: {
+      ...initialDateLimitYearMonth,
     },
     enabledPeriods: ['last_6_months', 'last_9_months', 'last_12_months'],
     value: ['2020-05', '2020-03'],
@@ -67,6 +99,57 @@ describe('datePicker component', () => {
 
     expect(datePickerVuetify().vm.$props.min).toBe(updatedDateLimit.min)
     expect(datePickerVuetify().vm.$props.max).toBe(updatedDateLimit.max)
+  })
+
+  it('renders bordered datepicker', async () => {
+    expect(datePicker.find('.LDatePickerMonth--bordered').exists()).toBe(false)
+
+    datePicker.setProps({ bordered: true })
+    await datePicker.vm.$nextTick()
+
+    expect( datePicker.find('.LDatePickerMonth--bordered').exists()).toBe(true)
+  })
+
+  it('renders right amount of disabled periods', async () => {
+    expect(datePicker.findAll('.v-chip--disabled').length).toBe(1)
+  })
+
+  it('renders period in asc order', async () => {
+    const inputText = datePicker.find('.formatted-months').text()
+    expect(inputText).toEqual(orderedPeriodAscTextMock)
+  })
+})
+
+describe('datePicker component when have only year and month', () => {
+  addElemWithDataAppToBody()
+  let datePicker: Wrapper<LDatePickerMonth>
+
+  beforeAll(() => {
+    datePicker = mount(LDatePickerMonth, {
+      ...yearAndMothParams
+    })
+  })
+
+  it('check datepicker limit', async () => {
+    expect(datePicker.exists()).toBeTruthy()
+    const activator = () => datePicker.find('.activator')
+
+    activator().trigger('click')
+    await datePicker.vm.$nextTick()
+
+    const calendar = () => datePicker.find('.v-date-picker-table')
+    expect(calendar().exists()).toBeTruthy()
+
+    const datePickerVuetify = () => datePicker.findComponent({ name: 'v-date-picker' })
+    expect(datePickerVuetify().exists()).toBeTruthy()
+    expect(datePickerVuetify().vm.$props.min).toBe(initialDateLimitYearMonth.min)
+    expect(datePickerVuetify().vm.$props.max).toBe(initialDateLimitYearMonth.max)
+
+    datePicker.setProps({ limit: updatedDateLimitYearMonth })
+    await datePicker.vm.$nextTick()
+
+    expect(datePickerVuetify().vm.$props.min).toBe(updatedDateLimitYearMonth.min)
+    expect(datePickerVuetify().vm.$props.max).toBe(updatedDateLimitYearMonth.max)
   })
 
   it('renders bordered datepicker', async () => {


### PR DESCRIPTION
## :package: Conteúdo

- Correção da seleção de data através dos props laterais de 3, 6, 9 e 12 meses que quando é enviado somente a data e ano para o componete LDatePickerMonth, ele traz um mês anterior do suposto.

## :heavy_check_mark: Tarefa(s)

- [LOG-72047](https://logcomex.atlassian.net/browse/LOG-72047)

## :eyes: Tarefa de Code Review (CR)

- [LOG-72574](https://logcomex.atlassian.net/browse/LOG-72574)

## :warning: Tipo de alteração
<!-- marcar uma das opções com x -->

- [x] Bug fix (não tem breaking change e resolve um bug) 
- [ ] Feature (não tem breaking change e adiciona nova(s) funcionalidade(s) ou componente(s)) 
- [ ] Breaking change (fix ou feature que faz com que uma funcionalidade já existente não funcione mais parcialmente ou totalmente)
- [ ] Melhoria/Refatoração (não tem breaking change, não adiciona nenhuma feature nova e nem corrige bug, no entanto, melhora a qualidade do código, documentação ou alguma outra coisa)
 
## :white_check_mark: Checklist
<!-- marcar com x o que se aplica, o que não se aplica manter vazio -->

- [x] Minha alteração não inclui regras de negócio <!-- Obrigatório -->
- [x] Meu código está de acordo com o [Vue Style Guide](https://v2.vuejs.org/v2/style-guide/?redirect=true) e o mais limpo possível <!-- Obrigatório -->
- [x] Feature anotada na release note <!-- Obrigatório -->
- [ ] Testes de snapshot passaram/foram aprovados <!-- Obrigatório, aguardar pela action mergeability que roda após ter 3 approves e os outros checks já terem passado. Se o mergeability estiver com fail após ter os approves e as outras checks já terem passado é necessário dar rerun. -->
- [ ] Documentação atualizada <!-- Necessário apenas se alterou API de algum componente ou se criou um componente novo --> 
- [x] Testes unitários atualizados <!-- Necessário apenas se alterou API de algum componente ou se criou um componente novo --> 
- [ ] Levantamento de componentes atualizado <!-- Necessário apenas se criou um componente novo -->


<!-- Links: https://logcomex.atlassian.net/wiki/spaces/ARQ/pages/24444950/Design+System -->

<!-- Após merge para homol, será gerada automaticamente uma versão beta que pode ser verificada no NPM e no resultado da action. Essa beta é a que você vai atualizar no seu produto caso não queira esperar a próxima versão estável do pacote -->
