### PR TITLE
(LOG-86343) - Adicionando footer slot no date picker day

### DIFF
--- a/docs/stories/components/inputs/LDatePickerDay.stories.js
+++ b/docs/stories/components/inputs/LDatePickerDay.stories.js
@@ -103,6 +103,9 @@ const TemplateWithSlot = (args, { argTypes }) => ({
           Value: {{ formattedDate }}
         </span>
       </template>
+      <template #footer>
+        Footer content
+      </template>
     </l-date-picker-day>
   `
 })

--- a/src/components/inputs/LDatePickerDay.vue
+++ b/src/components/inputs/LDatePickerDay.vue
@@ -112,6 +112,7 @@
           @mouseleave:date="leaveHoverDate"
         />
       </div>
+      <slot name="footer" />
     </v-menu>
   </div>
 </template>

--- a/test/components/inputs/lDatePickerDay.spec.ts
+++ b/test/components/inputs/lDatePickerDay.spec.ts
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/vue'
+import { getByText, screen, waitFor } from '@testing-library/vue'
 import { composeStories } from '@storybook/testing-vue'
 import userEvent from '@testing-library/user-event'
 import { renderComponent } from '~/test/utils.setup.testingLibrary'
@@ -113,5 +113,13 @@ describe('LDatePickerDay', () => {
     renderComponent(DefaultWithSlot())
 
     await checkDefaultDatepickerOpened()
+  })
+
+  it('renders default datepicker (with slot Footer)', async () => {
+    renderComponent(DefaultWithSlot())
+
+    await checkDefaultDatepickerOpened()
+    
+    expect(screen.getByText('Footer content')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## :package: Conteúdo

O Que

Como mostra neste novo protótipo criado, deve ser incluido no componente LDatePicker o slot do footer para permitir o uso do trigger.

Por que

Para a possibilidade de usar o datepicker como um filtro.

Resultado

DatePicker possibilidade de conter botões do footer.

## :heavy_check_mark: Tarefa(s)

- LOG-86343

## :eyes: Tarefa de Code Review (CR)

- LOG-XX

## :warning: Tipo de alteração
<!-- marcar uma das opções com x -->

- [ ] Bug fix (não tem breaking change e resolve um bug) 
- [x] Feature (não tem breaking change e adiciona nova(s) funcionalidade(s) ou componente(s)) 
- [ ] Breaking change (fix ou feature que faz com que uma funcionalidade já existente não funcione mais parcialmente ou totalmente)
- [ ] Melhoria/Refatoração (não tem breaking change, não adiciona nenhuma feature nova e nem corrige bug, no entanto, melhora a qualidade do código, documentação ou alguma outra coisa)
 
## :white_check_mark: Checklist
<!-- marcar com x o que se aplica, o que não se aplica manter vazio -->

- [x] Minha alteração não inclui regras de negócio <!-- Obrigatório -->
- [x] Meu código está de acordo com o [Vue Style Guide](https://v2.vuejs.org/v2/style-guide/?redirect=true) e o mais limpo possível <!-- Obrigatório -->
- [x] Feature anotada na release note <!-- Obrigatório -->
- [ ] Testes de snapshot passaram/foram aprovados <!-- Obrigatório, aguardar pela action mergeability que roda após ter 3 approves e os outros checks já terem passado. Se o mergeability estiver com fail após ter os approves e as outras checks já terem passado é necessário dar rerun. -->
- [ ] Documentação atualizada <!-- Necessário apenas se alterou API de algum componente ou se criou um componente novo --> 
- [ ] Testes unitários atualizados <!-- Necessário apenas se alterou API de algum componente ou se criou um componente novo --> 
- [ ] Levantamento de componentes atualizado <!-- Necessário apenas se criou um componente novo -->


<!-- Links: https://logcomex.atlassian.net/wiki/spaces/ARQ/pages/24444950/Design+System -->

<!-- Após merge para homol, será gerada automaticamente uma versão beta que pode ser verificada no NPM e no resultado da action. Essa beta é a que você vai atualizar no seu produto caso não queira esperar a próxima versão estável do pacote -->
